### PR TITLE
Hack fix for a bug in the spamThreat addresses

### DIFF
--- a/src/Components/Jason/SpamThreat.tsx
+++ b/src/Components/Jason/SpamThreat.tsx
@@ -36,6 +36,9 @@ const SpamThreat = ({
         dataObject.address = "(null sender)";
       }
 
+      // hack for removing the previous \n
+      dataObject.address = dataObject.address.replace("\n@", "@");
+
       // break at @
       dataObject.address = dataObject.address.replace("@", "\n@");
 


### PR DESCRIPTION
Line breaks would be added to the spam threat addresses on each render
This removes the existing line break before rendering, which is a temporary solution to prevent it from piling up